### PR TITLE
Setup esFrontLine on the old cluster

### DIFF
--- a/resources/config/nginx.conf
+++ b/resources/config/nginx.conf
@@ -52,6 +52,10 @@ http {
         server 127.0.0.1:8084;
     }
 
+    upstream elasticsearch {
+        server 127.0.0.1:8078;
+    }
+
     server {
         listen              80 default_server;
         server_name         activedata.allizom.org;
@@ -63,6 +67,13 @@ http {
 
         location /tools/ {
             alias /home/ec2-user/ActiveData/active_data/public/;
+        }
+
+        location /elasticsearch/ {
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header Host $http_host;
+            proxy_pass http://elasticsearch;
+            proxy_read_timeout 300;
         }
 
         access_log          /logs/nginx_access.log main;

--- a/resources/config/supervisord.conf
+++ b/resources/config/supervisord.conf
@@ -42,6 +42,17 @@ stdout_logfile=/logs/flask%(process_num)s.log
 user=ec2-user
 environment=PYTHONPATH='.',HOME='/home/ec2-user'
 
+[program:esFrontLine]
+command=/home/ec2-user/esFrontLine-env/bin/python esFrontLine/app.py --config=resources/config/prod.json
+directory=/home/ec2-user/esFrontLine
+autostart=true
+autorestart=true
+startretries=10
+stderr_logfile=/logs/supervisor_esFrontLine_error.log
+stdout_logfile=/logs/supervisor_esFrontLine.log
+user=ec2-user
+environment=PYTHONPATH="/home/ec2-user/esFrontLine:/home/ec2-user/esFrontLine/vendor:$PYTHONPATH",PYPY_GC_MAX='6GB',HOME='/home/ec2-user'
+
 # [program:gunicorn]
 # command=/usr/local/bin/gunicorn --pythonpath . --config resources/config/gunicorn.py 'active_data.app:setup(settings="resources/config/staging_settings.json")'
 # directory=/home/ec2-user/ActiveData

--- a/resources/scripts/active_data.esfrontline.sh
+++ b/resources/scripts/active_data.esfrontline.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -e
+
+FRONTLINE_DIR="/home/ec2-user/esFrontLine"
+FRONTLINE_ENV="/home/ec2-user/esFrontLine-env"
+BRANCH=activedata
+
+# Clone frontine
+if [[ ! -d $FRONTLINE_DIR ]] ; then
+	git clone https://github.com/mozilla/esFrontLine.git $FRONTLINE_DIR
+fi
+
+# Update to required branch
+cd $FRONTLINE_DIR
+git checkout $BRANCH
+git pull origin $BRANCH
+
+# Install requirements in virtualenv
+if [[ ! -d $FRONTLINE_ENV ]] ; then
+	virtualenv $FRONTLINE_ENV
+fi
+source ${FRONTLINE_ENV}/bin/activate
+pip install -r ${FRONTLINE_DIR}/requirements.txt


### PR DESCRIPTION
* Added a script to clone esFrontline and setup its python dependencies in a virtualenv
* Supervisor setup using Python from the virtualenv
* Nginx configuration backported from the new cluster

I tested the scripts & supervisor command line in a fresh Debian docker instance