### PR TITLE
Handle math ops on multi-type columns

### DIFF
--- a/active_data/actions/query.py
+++ b/active_data/actions/query.py
@@ -65,7 +65,7 @@ def jx_query(path):
                     if isinstance(result, Container):  # TODO: REMOVE THIS CHECK, jx SHOULD ALWAYS RETURN Containers
                         result = result.format(data.format)
 
-                save_timer = Timer("save")
+                save_timer = Timer("save", silent=not DEBUG)
                 with save_timer:
                     if data.meta.save:
                         try:

--- a/vendor/jx_base/expressions.py
+++ b/vendor/jx_base/expressions.py
@@ -974,10 +974,10 @@ class DivOp(BaseBinaryOp):
     op = "div"
 
     def missing(self):
-        return AndOp([
+        return self.lang[AndOp([
             self.default.missing(),
-            self.lang[OrOp([self.lhs.missing(), self.rhs.missing(), EqOp([self.rhs, ZERO])])]
-        ]).partial_eval()
+            OrOp([self.lhs.missing(), self.rhs.missing(), EqOp([self.rhs, ZERO])])
+        ])].partial_eval()
 
     def partial_eval(self):
         default = self.default.partial_eval()

--- a/vendor/jx_elasticsearch/es52/painless.py
+++ b/vendor/jx_elasticsearch/es52/painless.py
@@ -607,7 +607,7 @@ class BasicEqOp(BasicEqOp_):
             else:
                 return EsScript(
                     type=BOOLEAN,
-                    expr="(" + lhs.expr + "==" + rhs.expr + ")",
+                    expr="(" + lhs.expr + ")==(" + rhs.expr + ")",
                     frum=self,
                     schema=schema,
                 )

--- a/vendor/mo_logs/startup.py
+++ b/vendor/mo_logs/startup.py
@@ -76,7 +76,12 @@ def read_settings(defs=None, filename=None, default_filename=None):
     })
     args = argparse(defs)
 
-    args.filename = coalesce(filename, args.filename, default_filename, "./config.json")
+    args.filename = coalesce(
+        filename,
+        args.filename if args.filename.endswith(".json") else None,
+        default_filename,
+        "./config.json"
+    )
     settings_file = File(args.filename)
     if settings_file.exists:
         Log.note("Using {{filename}} for configuration", filename=settings_file.abspath)


### PR DESCRIPTION
The schema has been polluted with strings, which was expected, but handling was still buggy.