### PR TITLE
Bulk query

### DIFF
--- a/active_data/app.py
+++ b/active_data/app.py
@@ -25,6 +25,7 @@ from active_data.actions.save_query import SaveQueries, find_query
 from active_data.actions.sql import sql_query
 from active_data.actions.static import download, send_favicon
 from jx_base import container
+from jx_elasticsearch.es52 import bulk_aggs
 from mo_dots import is_data
 from mo_files import File, TempFile
 from mo_future import text
@@ -114,6 +115,8 @@ def setup():
 
     constants.set(config.constants)
     Log.start(config.debug)
+
+    bulk_aggs.S3_CONFIG = config.bulk.s3
 
     File.new_instance("activedata.pid").write(text(machine_metadata.pid))
 

--- a/tests/config/app_config.json
+++ b/tests/config/app_config.json
@@ -32,6 +32,13 @@
 			"$ref": "//.../resources/schema/request_log.schema.json"
 		}
 	},
+	"bulk": {
+		"s3": {
+			"bucket": "active-data-query-results",
+			"public": true,
+			"$ref": "file://~/private.json#aws_credentials"
+		}
+	},
 	"saved_queries": {
 		"host": "http://localhost",
 		"port": 9200,

--- a/tests/test_es_special.py
+++ b/tests/test_es_special.py
@@ -10,6 +10,9 @@
 
 from __future__ import absolute_import, division, unicode_literals
 
+from unittest import skipIf
+
+from jx_elasticsearch.es52 import bulk_aggs
 from jx_python import jx
 from mo_dots import set_default, wrap
 from mo_future import text
@@ -168,6 +171,7 @@ class TestESSpecial(BaseTestCase):
 
         self.utils.execute_tests(test)
 
+    @skipIf(bulk_aggs.S3_CONFIG, "can not test S3")
     def test_bulk_query(self):
         data = wrap([{"a": "test" + text(i)} for i in range(1001)])
         expected = [{"a": r.a, "count": 1} for r in data]
@@ -178,6 +182,7 @@ class TestESSpecial(BaseTestCase):
                 "from": TEST_TABLE,
                 "groupby": "a",
                 "limit": len(data),
+                "chunk_size": 100,
                 "format": "list",
             },
             "expecting_list": {"data": expected},  # DUMMY< TO ENSURE LOADED
@@ -186,7 +191,7 @@ class TestESSpecial(BaseTestCase):
         self.utils.execute_tests(test)
         result = http.post_json(
             url=self.utils.testing.query,
-            json=set_default({"destination": "s3", "limit": 100}, test.query),
+            json=set_default({"destination": "s3"}, test.query),
         )
 
         timeout = Till(seconds=MINUTE.seconds)

--- a/tests/test_es_special.py
+++ b/tests/test_es_special.py
@@ -10,10 +10,11 @@
 
 from __future__ import absolute_import, division, unicode_literals
 
-from jx_base.meta_columns import META_COLUMNS_NAME
-from mo_dots import wrap
-from mo_times import Date
-from pyLibrary.sql.sqlite import Sqlite, sql_insert
+from mo_dots import set_default, wrap
+from mo_future import text
+from mo_threads import Till
+from mo_times import MINUTE
+from pyLibrary.env import http
 from tests.test_jx import BaseTestCase, TEST_TABLE
 
 
@@ -24,142 +25,173 @@ class TestESSpecial(BaseTestCase):
 
     def test_query_on_es_base_field(self):
         schema = {
-            "settings": {"analysis": {
-                "analyzer": {"whiteboard_tokens": {
-                    "type": "custom",
-                    "tokenizer": "whiteboard_tokens_pattern",
-                    "filter": ["stop"]
-                }},
-                "tokenizer": {"whiteboard_tokens_pattern": {
-                    "type": "pattern",
-                    "pattern": "\\s*([,;]*\\[|\\][\\s\\[]*|[;,])\\s*"
-                }}
-            }},
-            "mappings": {"test_result": {
-                "properties": {"status_whiteboard": {
-                    "type": "keyword",
-                    "store": True,
-                    "fields": {"tokenized": {"type": "text", "analyzer": "whiteboard_tokens"}}
-                }}
-            }}
+            "settings": {
+                "analysis": {
+                    "analyzer": {
+                        "whiteboard_tokens": {
+                            "type": "custom",
+                            "tokenizer": "whiteboard_tokens_pattern",
+                            "filter": ["stop"],
+                        }
+                    },
+                    "tokenizer": {
+                        "whiteboard_tokens_pattern": {
+                            "type": "pattern",
+                            "pattern": "\\s*([,;]*\\[|\\][\\s\\[]*|[;,])\\s*",
+                        }
+                    },
+                }
+            },
+            "mappings": {
+                "test_result": {
+                    "properties": {
+                        "status_whiteboard": {
+                            "type": "keyword",
+                            "store": True,
+                            "fields": {
+                                "tokenized": {
+                                    "type": "text",
+                                    "analyzer": "whiteboard_tokens",
+                                }
+                            },
+                        }
+                    }
+                }
+            },
         }
 
         test = {
             "schema": schema,
-            "data": [
-                {
-                    "bug_id": 123,
-                    "status_whiteboard": "[test][fx21]"
-                }
-            ],
-            "query": {
-                "select": ["status_whiteboard"],
-                "from": TEST_TABLE
-            },
+            "data": [{"bug_id": 123, "status_whiteboard": "[test][fx21]"}],
+            "query": {"select": ["status_whiteboard"], "from": TEST_TABLE},
             "expecting_list": {
-                "meta": {"format": "list"}, "data": [{"status_whiteboard": "[test][fx21]"}]
-            }
+                "meta": {"format": "list"},
+                "data": [{"status_whiteboard": "[test][fx21]"}],
+            },
         }
         self.utils.execute_tests(test)
 
     def test_query_on_es_sub_field(self):
         schema = {
-            "settings": {"analysis": {
-                "analyzer": {"whiteboard_tokens": {
-                    "type": "custom",
-                    "tokenizer": "whiteboard_tokens_pattern",
-                    "filter": ["stop"]
-                }},
-                "tokenizer": {"whiteboard_tokens_pattern": {
-                    "type": "pattern",
-                    "pattern": "\\s*([,;]*\\[|\\][\\s\\[]*|[;,])\\s*"
-                }}
-            }},
-            "mappings": {"test_result": {
-                "properties": {"status_whiteboard": {
-                    "type": "keyword",
-                    "store": True,
-                    "fields": {"tokenized": {"type": "text", "analyzer": "whiteboard_tokens"}}
-                }}
-            }}
+            "settings": {
+                "analysis": {
+                    "analyzer": {
+                        "whiteboard_tokens": {
+                            "type": "custom",
+                            "tokenizer": "whiteboard_tokens_pattern",
+                            "filter": ["stop"],
+                        }
+                    },
+                    "tokenizer": {
+                        "whiteboard_tokens_pattern": {
+                            "type": "pattern",
+                            "pattern": "\\s*([,;]*\\[|\\][\\s\\[]*|[;,])\\s*",
+                        }
+                    },
+                }
+            },
+            "mappings": {
+                "test_result": {
+                    "properties": {
+                        "status_whiteboard": {
+                            "type": "keyword",
+                            "store": True,
+                            "fields": {
+                                "tokenized": {
+                                    "type": "text",
+                                    "analyzer": "whiteboard_tokens",
+                                }
+                            },
+                        }
+                    }
+                }
+            },
         }
 
         test = {
             "schema": schema,
             "data": [
-                {
-                    "bug_id": 123,
-                    "status_whiteboard": "[test][fx21]"
-                },
-                {
-                    "bug_id": 124,
-                    "status_whiteboard": "[test]"
-                },
-                {
-                    "bug_id": 125
-                },
+                {"bug_id": 123, "status_whiteboard": "[test][fx21]"},
+                {"bug_id": 124, "status_whiteboard": "[test]"},
+                {"bug_id": 125},
             ],
             "query": {
                 "select": ["bug_id"],
                 "from": TEST_TABLE,
-                "where": {"eq": {"status_whiteboard.tokenized": "test"}}
+                "where": {"eq": {"status_whiteboard.tokenized": "test"}},
             },
             "expecting_list": {
                 "meta": {"format": "list"},
-                "data": [{"bug_id": 123}, {"bug_id": 124}]
-            }
+                "data": [{"bug_id": 123}, {"bug_id": 124}],
+            },
         }
         self.utils.execute_tests(test)
 
     def test_query_on_null_startswith(self):
         schema = {
-            "mappings": {"test_result": {
-                "properties": {"name": {
-                    "type": "keyword",
-                    "store": True
-                }}
-            }}
+            "mappings": {
+                "test_result": {
+                    "properties": {"name": {"type": "keyword", "store": True}}
+                }
+            }
         }
 
         test = {
             "schema": schema,
-            "data": [
-            ],
+            "data": [],
             "query": {
                 "where": {"prefix": {"no_name": "something"}},
-                "from": TEST_TABLE
+                "from": TEST_TABLE,
             },
-            "expecting_list": {
-                "meta": {"format": "list"}, "data": []
-            }
+            "expecting_list": {"meta": {"format": "list"}, "data": []},
         }
         self.utils.execute_tests(test)
 
     def test_prefix_uses_prefix(self):
         test = {
-            "data": [
-                {"a": "test"},
-                {"a": "testkyle"},
-                {"a": None}
-            ],
-            "query": {
-                "from": TEST_TABLE,
-                "where": {"prefix": {"a": "test"}}
-            },
+            "data": [{"a": "test"}, {"a": "testkyle"}, {"a": None}],
+            "query": {"from": TEST_TABLE, "where": {"prefix": {"a": "test"}}},
             "expecting_list": {
                 "meta": {
                     "format": "list",
                     "es_query": {
                         "from": 0,
                         "query": {"prefix": {"a.~s~": "test"}},
-                        "size": 10
-                    }
+                        "size": 10,
+                    },
                 },
-                "data": [
-                    {"a": "test"},
-                    {"a": "testkyle"}
-                ]
-            }
+                "data": [{"a": "test"}, {"a": "testkyle"}],
+            },
         }
 
         self.utils.execute_tests(test)
+
+    def test_bulk_query(self):
+        data = wrap([{"a": "test" + text(i)} for i in range(1001)])
+        expected = [{"a": r.a, "count": 1} for r in data]
+
+        test = wrap({
+            "data": data,
+            "query": {
+                "from": TEST_TABLE,
+                "groupby": "a",
+                "limit": len(data),
+                "format": "list",
+            },
+            "expecting_list": {"data": expected},  # DUMMY< TO ENSURE LOADED
+        })
+
+        self.utils.execute_tests(test)
+        result = http.post_json(
+            url=self.utils.testing.query,
+            json=set_default({"meta": {"big": True}, "limit": 100}, test.query),
+        )
+
+        timeout = Till(seconds=MINUTE.seconds)
+        while not timeout:
+            try:
+                content = http.get(result.url)
+                self.assertEqual(content, expected)
+                break
+            except Exception:
+                Till(seconds=2).wait()

--- a/vendor/jx_base/container.py
+++ b/vendor/jx_base/container.py
@@ -114,10 +114,6 @@ class Container(object):
     def window(self, window):
         raise NotImplementedError()
 
-    def having(self, having):
-        _ = having
-        raise NotImplementedError()
-
     def format(self, format):
         _ = format
         raise NotImplementedError()

--- a/vendor/jx_base/namespace.py
+++ b/vendor/jx_base/namespace.py
@@ -34,7 +34,6 @@ class Namespace(object):
         output.where = self.convert(query.where)
         output["from"] = self._convert_from(query["from"])
         output.edges = self._convert_clause(query.edges)
-        output.having = convert_list(self._convert_having, query.having)
         output.window = convert_list(self._convert_window, query.window)
         output.sort = self._convert_clause(query.sort)
         output.format = query.format
@@ -45,9 +44,6 @@ class Namespace(object):
         raise NotImplementedError()
 
     def _convert_clause(self, clause):
-        raise NotImplementedError()
-
-    def _convert_having(self, clause):
         raise NotImplementedError()
 
     def _convert_window(self, clause):

--- a/vendor/jx_base/query.py
+++ b/vendor/jx_base/query.py
@@ -46,7 +46,7 @@ def _late_import():
 
 
 class QueryOp(QueryOp_):
-    __slots__ = ["frum", "select", "edges", "groupby", "where", "window", "sort", "limit", "having", "format", "isLean"]
+    __slots__ = ["frum", "select", "edges", "groupby", "where", "window", "sort", "limit", "format", "isLean"]
 
     # def __new__(cls, op=None, frum=None, select=None, edges=None, groupby=None, window=None, where=None, sort=None, limit=None, format=None):
     #     output = object.__new__(cls)
@@ -235,7 +235,6 @@ class QueryOp(QueryOp_):
 
         output.where = _normalize_where({"and": listwrap(query.where)}, schema=schema)
         output.window = [_normalize_window(w) for w in listwrap(query.window)]
-        output.having = None
         output.sort = _normalize_sort(query.sort)
         if not mo_math.is_integer(output.limit) or output.limit < 0:
             Log.error("Expecting limit >= 0")

--- a/vendor/jx_base/query.py
+++ b/vendor/jx_base/query.py
@@ -46,9 +46,9 @@ def _late_import():
 
 
 class QueryOp(QueryOp_):
-    __slots__ = ["frum", "select", "edges", "groupby", "where", "window", "sort", "limit", "format", "isLean", "destination"]
+    __slots__ = ["frum", "select", "edges", "groupby", "where", "window", "sort", "limit", "format", "chunk_size", "destination"]
 
-    def __init__(self,frum, select=None, edges=None, groupby=None, window=None, where=None, sort=None, limit=None, format=None, destination=None):
+    def __init__(self,frum, select=None, edges=None, groupby=None, window=None, where=None, sort=None, limit=None, format=None, chunk_size=None, destination=None):
         if isinstance(frum, jx_base.Table):
             pass
         else:
@@ -62,6 +62,7 @@ class QueryOp(QueryOp_):
         self.sort = sort
         self.limit = limit
         self.format = format
+        self.chunk_size = chunk_size
         self.destination = destination
 
     def __data__(self):
@@ -206,7 +207,8 @@ class QueryOp(QueryOp_):
             frum=table,
             format=query.format,
             limit=mo_math.min(MAX_LIMIT, coalesce(query.limit, DEFAULT_LIMIT)),
-            destination=query.destination
+            chunk_size=query.chunk_size,
+            destination=query.destination,
         )
 
         if query.select or isinstance(query.select, (Mapping, list)):
@@ -234,8 +236,6 @@ class QueryOp(QueryOp_):
         output.sort = _normalize_sort(query.sort)
         if not mo_math.is_integer(output.limit) or output.limit < 0:
             Log.error("Expecting limit >= 0")
-
-        output.isLean = query.isLean
 
         return output
 

--- a/vendor/jx_base/query.py
+++ b/vendor/jx_base/query.py
@@ -46,15 +46,9 @@ def _late_import():
 
 
 class QueryOp(QueryOp_):
-    __slots__ = ["frum", "select", "edges", "groupby", "where", "window", "sort", "limit", "format", "isLean"]
+    __slots__ = ["frum", "select", "edges", "groupby", "where", "window", "sort", "limit", "format", "isLean", "destination"]
 
-    # def __new__(cls, op=None, frum=None, select=None, edges=None, groupby=None, window=None, where=None, sort=None, limit=None, format=None):
-    #     output = object.__new__(cls)
-    #     for s in QueryOp.__slots__:
-    #         setattr(output, s, None)
-    #     return output
-
-    def __init__(self,frum, select=None, edges=None, groupby=None, window=None, where=None, sort=None, limit=None, format=None):
+    def __init__(self,frum, select=None, edges=None, groupby=None, window=None, where=None, sort=None, limit=None, format=None, destination=None):
         if isinstance(frum, jx_base.Table):
             pass
         else:
@@ -68,6 +62,7 @@ class QueryOp(QueryOp_):
         self.sort = sort
         self.limit = limit
         self.format = format
+        self.destination = destination
 
     def __data__(self):
         def select___data__():
@@ -210,7 +205,8 @@ class QueryOp(QueryOp_):
         output = QueryOp(
             frum=table,
             format=query.format,
-            limit=mo_math.min(MAX_LIMIT, coalesce(query.limit, DEFAULT_LIMIT))
+            limit=mo_math.min(MAX_LIMIT, coalesce(query.limit, DEFAULT_LIMIT)),
+            destination=query.destination
         )
 
         if query.select or isinstance(query.select, (Mapping, list)):

--- a/vendor/jx_base/query.py
+++ b/vendor/jx_base/query.py
@@ -206,7 +206,7 @@ class QueryOp(QueryOp_):
         output = QueryOp(
             frum=table,
             format=query.format,
-            limit=mo_math.min(MAX_LIMIT, coalesce(query.limit, DEFAULT_LIMIT)),
+            limit=temper_limit(query.limit, query),
             chunk_size=query.chunk_size,
             destination=query.destination,
         )
@@ -266,6 +266,16 @@ class QueryOp(QueryOp_):
     def __data__(self):
         output = wrap({s: getattr(self, s) for s in QueryOp.__slots__})
         return output
+
+
+def temper_limit(proposed_limit, query):
+    """
+    SUITABLE DEFAULTS AND LIMITS
+    """
+    if query.destination == "s3":
+        return coalesce(proposed_limit, query.limit)
+    else:
+        return mo_math.min(coalesce(proposed_limit, query.limit, DEFAULT_LIMIT), MAX_LIMIT)
 
 
 canonical_aggregates = wrap({

--- a/vendor/jx_elasticsearch/es52/__init__.py
+++ b/vendor/jx_elasticsearch/es52/__init__.py
@@ -197,7 +197,7 @@ class ES52(Container):
                 return jx.run(q2)
 
             if is_bulkaggsop(self.es, query):
-                return es_bulkaggsop(self.es, frum, query)
+                return es_bulkaggsop(self, frum, query)
             if is_deepop(self.es, query):
                 return es_deepop(self.es, query)
             if is_aggsop(self.es, query):

--- a/vendor/jx_elasticsearch/es52/__init__.py
+++ b/vendor/jx_elasticsearch/es52/__init__.py
@@ -16,6 +16,7 @@ from jx_base.expressions import jx_expression
 from jx_base.language import is_op
 from jx_base.query import QueryOp
 from jx_elasticsearch.es52.aggs import es_aggsop, is_aggsop
+from jx_elasticsearch.es52.bulk_aggs import is_bulkaggsop, es_bulkaggsop
 from jx_elasticsearch.es52.deep import es_deepop, is_deepop
 from jx_elasticsearch.es52.setop import es_setop, is_setop
 from jx_elasticsearch.es52.util import aggregates
@@ -195,6 +196,8 @@ class ES52(Container):
                 q2.frum = result
                 return jx.run(q2)
 
+            if is_bulkaggsop(self.es, query):
+                return es_bulkaggsop(self.es, frum, query)
             if is_deepop(self.es, query):
                 return es_deepop(self.es, query)
             if is_aggsop(self.es, query):

--- a/vendor/jx_elasticsearch/es52/aggs.py
+++ b/vendor/jx_elasticsearch/es52/aggs.py
@@ -170,11 +170,10 @@ def sort_edges(query, prop):
     return ordered_edges
 
 
-def es_aggsop(es, frum, query):
-    query = query.copy()  # WE WILL MARK UP THIS QUERY
-    schema = frum.schema
-    query_path = schema.query_path[0]
-    select = listwrap(query.select)
+def extract_aggs(select, query_path, schema):
+    """
+    RETURN ES AGGREGATIONS
+    """
 
     new_select = Data()  # MAP FROM canonical_name (USED FOR NAMES IN QUERY) TO SELECT MAPPING
     formula = []
@@ -194,14 +193,15 @@ def es_aggsop(es, frum, query):
                     s.query_path = si_key
             formula.append(s)
 
+
     acc = Aggs()
     for _, many in new_select.items():
         for s in many:
             canonical_name = s.name
             if s.aggregate in ("value_count", "count"):
-                columns = frum.schema.values(s.value.var, exclude_type=(OBJECT, NESTED))
+                columns = schema.values(s.value.var, exclude_type=(OBJECT, NESTED))
             else:
-                columns = frum.schema.values(s.value.var)
+                columns = schema.values(s.value.var)
 
             if s.aggregate == "count":
                 canonical_names = []
@@ -236,7 +236,8 @@ def es_aggsop(es, frum, query):
             elif s.aggregate == "percentile":
                 columns = [c for c in columns if c.jx_type in (NUMBER, INTEGER)]
                 if len(columns) != 1:
-                    Log.error("Do not know how to perform percentile on columns with more than one type (script probably)")
+                    Log.error(
+                        "Do not know how to perform percentile on columns with more than one type (script probably)")
                 # ES USES DIFFERENT METHOD FOR PERCENTILES
                 key = canonical_name + " percentile"
                 if is_text(s.percentile) or s.percetile < 0 or 1 < s.percentile:
@@ -264,7 +265,8 @@ def es_aggsop(es, frum, query):
 
                 # GET MEDIAN TOO!
                 select_median = s.copy()
-                select_median.pull = jx_expression_to_function({"select": [{"name": "median", "value": "values.50\\.0"}]})
+                select_median.pull = jx_expression_to_function(
+                    {"select": [{"name": "median", "value": "values.50\\.0"}]})
 
                 acc.add(ExprAggs(canonical_name + "_percentile", {"percentiles": {
                     "field": first(columns).es_column,
@@ -275,7 +277,8 @@ def es_aggsop(es, frum, query):
                 for column in columns:
                     script = {"scripted_metric": {
                         'init_script': 'params._agg.terms = new HashSet()',
-                        'map_script': 'for (v in doc['+quote(column.es_column)+'].values) params._agg.terms.add(v);',
+                        'map_script': 'for (v in doc[' + quote(
+                            column.es_column) + '].values) params._agg.terms.add(v);',
                         'combine_script': 'return params._agg.terms.toArray()',
                         'reduce_script': 'HashSet output = new HashSet(); for (a in params._aggs) { if (a!=null) for (v in a) {output.add(v)} } return output.toArray()',
                     }}
@@ -289,7 +292,8 @@ def es_aggsop(es, frum, query):
                     script = {"scripted_metric": {
                         'params': {"_agg": {}},
                         'init_script': 'params._agg.terms = new HashMap()',
-                        'map_script': 'for (v in doc['+quote(column.es_column)+'].values) params._agg.terms.put(v, Optional.ofNullable(params._agg.terms.get(v)).orElse(0)+1);',
+                        'map_script': 'for (v in doc[' + quote(
+                            column.es_column) + '].values) params._agg.terms.put(v, Optional.ofNullable(params._agg.terms.get(v)).orElse(0)+1);',
                         'combine_script': 'return params._agg.terms',
                         'reduce_script': '''
                             HashMap output = new HashMap(); 
@@ -317,6 +321,7 @@ def es_aggsop(es, frum, query):
                         ))
                     s.pull = jx_expression_to_function(aggregates[s.aggregate])
 
+    # DUPLICATED FOR SCRIPTS, MAYBE THIS CAN BE PUT INTO A LANGUAGE?
     for i, s in enumerate(formula):
         s_path = [k for k, v in split_expression_by_path(s.value, schema=schema, lang=Painless).items() if v]
         if len(s_path) == 0:
@@ -342,14 +347,18 @@ def es_aggsop(es, frum, query):
                     dir = -1
                     op = 'min'
 
-                nully = Painless[TupleOp([NULL]*len(s.value.terms))].partial_eval().to_es_script(schema)
+                nully = Painless[TupleOp([NULL] * len(s.value.terms))].partial_eval().to_es_script(schema)
                 selfy = text(Painless[s.value].partial_eval().to_es_script(schema))
 
                 script = {"scripted_metric": {
                     'init_script': 'params._agg.best = ' + nully + '.toArray();',
-                    'map_script': 'params._agg.best = ' + expand_template(MAX_OF_TUPLE, {"expr1": "params._agg.best", "expr2": selfy, "dir": dir, "op": op}) + ";",
+                    'map_script': 'params._agg.best = ' + expand_template(MAX_OF_TUPLE,
+                                                                          {"expr1": "params._agg.best", "expr2": selfy,
+                                                                           "dir": dir, "op": op}) + ";",
                     'combine_script': 'return params._agg.best',
-                    'reduce_script': 'return params._aggs.stream().'+op+'(' + expand_template(COMPARE_TUPLE, {"dir": dir, "op": op}) + ').get()',
+                    'reduce_script': 'return params._aggs.stream().' + op + '(' + expand_template(COMPARE_TUPLE,
+                                                                                                  {"dir": dir,
+                                                                                                   "op": op}) + ').get()',
                 }}
                 nest.add(NestedAggs(query_path).add(
                     ExprAggs(canonical_name, script, s)
@@ -358,7 +367,9 @@ def es_aggsop(es, frum, query):
             else:
                 Log.error("{{agg}} is not a supported aggregate over a tuple", agg=s.aggregate)
         elif s.aggregate == "count":
-            nest.add(ExprAggs(canonical_name, {"value_count": {"script": text(Painless[s.value].partial_eval().to_es_script(schema))}}, s))
+            nest.add(ExprAggs(canonical_name,
+                              {"value_count": {"script": text(Painless[s.value].partial_eval().to_es_script(schema))}},
+                              s))
             s.pull = jx_expression_to_function("value")
         elif s.aggregate == "median":
             # ES USES DIFFERENT METHOD FOR PERCENTILES THAN FOR STATS AND COUNT
@@ -384,7 +395,9 @@ def es_aggsop(es, frum, query):
             s.pull = jx_expression_to_function("value")
         elif s.aggregate == "stats":
             # REGULAR STATS
-            nest.add(ExprAggs(canonical_name, {"extended_stats": {"script": text(Painless[s.value].to_es_script(schema))}}, s))
+            nest.add(
+                ExprAggs(canonical_name, {"extended_stats": {"script": text(Painless[s.value].to_es_script(schema))}},
+                         s))
             s.pull = get_pull_stats()
 
             # GET MEDIAN TOO!
@@ -403,18 +416,22 @@ def es_aggsop(es, frum, query):
         else:
             # PULL VALUE OUT OF THE stats AGGREGATE
             s.pull = jx_expression_to_function(aggregates[s.aggregate])
-            nest.add(ExprAggs(canonical_name, {"extended_stats": {"script": text(NumberOp(s.value).partial_eval().to_es_script(schema))}}, s))
+            nest.add(ExprAggs(canonical_name, {
+                "extended_stats": {"script": text(NumberOp(s.value).partial_eval().to_es_script(schema))}}, s))
+    return acc
 
+
+def build_es_query(select, query_path, schema, query):
+    acc = extract_aggs(select, query_path, schema)
     acc = NestedAggs(query_path).add(acc)
     split_decoders = get_decoders_by_path(query)
-    split_wheres = split_expression_by_path(query.where, schema=frum.schema, lang=ES52)
-
+    split_wheres = split_expression_by_path(query.where, schema=schema, lang=ES52)
     start = 0
     decoders = [None] * (len(query.edges) + len(query.groupby))
     paths = list(reversed(sorted(set(split_wheres.keys()) | set(split_decoders.keys()))))
     for path in paths:
-        decoder = split_decoders.get(path)
-        where = split_wheres.get(path)
+        decoder = split_decoders.get(path, Null)
+        where = split_wheres.get(path, Null)
 
         for d in decoder:
             decoders[d.edge.dim] = d
@@ -424,12 +441,20 @@ def es_aggsop(es, frum, query):
         if where:
             acc = FilterAggs("_filter", AndOp(where), None).add(acc)
         acc = NestedAggs(path).add(acc)
-
     acc = NestedAggs('.').add(acc)
     acc = simplify(acc)
     es_query = wrap(acc.to_es(schema))
-
     es_query.size = 0
+    return acc, decoders, es_query
+
+
+def es_aggsop(es, frum, query):
+    query = query.copy()  # WE WILL MARK UP THIS QUERY
+    schema = frum.schema
+    query_path = schema.query_path[0]
+    selects = listwrap(query.select)
+
+    acc, decoders, es_query = build_es_query(selects, query_path, schema, query)
 
     with Timer("ES query time", silent=not DEBUG) as es_duration:
         result = es_post(es, es_query, query.limit)
@@ -437,16 +462,17 @@ def es_aggsop(es, frum, query):
     try:
         format_time = Timer("formatting", silent=not DEBUG)
         with format_time:
-            # result.aggregations.doc_count = coalesce(result.aggregations.doc_count, result.hits.total)  # IT APPEARS THE OLD doc_count IS GONE
+            # result.aggregations.doc_count = coalesce(result.aggregations.doc_count, result.hits.total)
+            # IT APPEARS THE OLD doc_count IS GONE
             aggs = unwrap(result.aggregations)
 
             formatter, groupby_formatter, aggop_formatter, mime_type = format_dispatch[query.format]
             if query.edges:
-                output = formatter(aggs, acc, query, decoders, select)
+                output = formatter(aggs, acc, query, decoders, selects)
             elif query.groupby:
-                output = groupby_formatter(aggs, acc, query, decoders, select)
+                output = groupby_formatter(aggs, acc, query, decoders, selects)
             else:
-                output = aggop_formatter(aggs, acc, query, decoders, select)
+                output = aggop_formatter(aggs, acc, query, decoders, selects)
 
         output.meta.timing.formatting = format_time.duration
         output.meta.timing.es_search = es_duration.duration

--- a/vendor/jx_elasticsearch/es52/bulk_aggs.py
+++ b/vendor/jx_elasticsearch/es52/bulk_aggs.py
@@ -1,0 +1,157 @@
+# encoding: utf-8
+#
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http:# mozilla.org/MPL/2.0/.
+#
+# Author: Kyle Lahnakoski (kyle@lahnakoski.com)
+#
+from __future__ import absolute_import, division, unicode_literals
+
+import gzip
+from contextlib import closing
+
+from jx_base.expressions import Variable, value2json
+from jx_base.language import is_op
+from jx_elasticsearch import post as es_post
+from jx_elasticsearch.es52.aggs import build_es_query
+from jx_elasticsearch.es52.format import format_list_from_groupby
+from mo_dots import listwrap, unwrap, unwraplist, Null
+from mo_files import TempFile, URL, mimetype
+from mo_future import first
+from mo_logs import Log
+from mo_math.randoms import Random
+from mo_threads import Till, Thread
+from mo_times import Date, DAY
+from mo_times.timer import Timer
+from pyLibrary.aws.s3 import Connection
+
+DEBUG = False
+CHUNK_SIZE = 5000
+URL_PREFIX = URL("http://activedata.allizom.org/results/")
+S3_CONFIG = Null
+
+
+def is_bulkaggsop(es, query):
+    # ONLY ACCEPTING ONE DIMENSION AT THIS TIME
+    if not S3_CONFIG:
+        return False
+    if not query.meta.big:
+        return False
+    if len(listwrap(query.groupby)) != 1:
+        return False
+    if not is_op(unwraplist(query.groupby).value, Variable):
+        return False
+    if query.format != "list":
+        return False
+    return True
+
+
+def es_bulkaggsop(es, frum, query):
+    query = query.copy()  # WE WILL MARK UP THIS QUERY
+    schema = frum.schema
+    query_path = schema.query_path[0]
+    selects = listwrap(query.select)
+
+    variable = unwraplist(query.groupby).value
+    # FIND CARDINALITY
+
+    cardinality_check = Timer(
+        "Get cardinality for {{column}}", param={"column": variable.var}
+    )
+    with cardinality_check:
+        columns = es.namespace.get_columns(
+            first(query_path),
+            column_name=variable.var,
+            after=Date.now() - DAY,
+            timeout=Till(seconds=30),
+        )
+
+        num_partitions = (first(columns).cardinality + CHUNK_SIZE) // CHUNK_SIZE
+        acc, decoders, es_query = build_es_query(selects, query_path, schema, query)
+        filename = Random.base64(32)+ ".json.gz"
+        if len(columns) != 1:
+            Log.error("too many columns to bulk groupby")
+
+        Thread.run(
+            "extract to " + filename,
+            extractor,
+            filename,
+            es_query,
+            num_partitions,
+            es,
+            acc,
+            query,
+            decoders,
+            selects,
+        )
+
+    output = {
+        "meta": {
+            "format": "bulk",
+            "url": URL_PREFIX / filename ,
+            "timing": {"cardinality_check": cardinality_check.duration},
+            "es_query": es_query,
+            "num_partitions": num_partitions,
+        }
+    }
+    return output
+
+
+def extractor(
+    filename, es_query, num_partitions, es, acc, query, decoders, selects, please_stop
+):
+    # FIND THE include POINT
+    curr = es_query
+    while True:
+        if curr._filter:
+            curr = curr._filter.aggs
+        elif curr._match:
+            break
+        else:
+            Log.error("can not handle")
+    missing = curr._missing
+    curr._missing = None
+    exists = curr._match
+
+    exists.size = CHUNK_SIZE
+    exists.include.num_partitions = num_partitions
+
+    with TempFile() as temp_file:
+        with open(temp_file._filename, "wb") as output_file:
+            with closing(gzip.GzipFile(fileobj=output_file, mode='wb')) as archive:
+                archive.write(b"[\n")
+                comma = b""
+                for i in range(0, num_partitions):
+                    if please_stop:
+                        return
+                    is_last = i == num_partitions - 1
+                    if is_last:
+                        # INCLUDE MISSING AT LAST
+                        curr._missing = missing
+                    exists.include.partition = i
+
+                    result = es_post(es, es_query, CHUNK_SIZE)
+                    aggs = unwrap(result.aggregations)
+                    data = format_list_from_groupby(
+                        aggs, acc, query, decoders, selects
+                    ).data
+
+                    for r in data:
+                        archive.write(comma)
+                        comma = b",\n"
+                        archive.write(value2json(r).encode("utf8"))
+                archive.write(b"\n]\n")
+
+        # PUSH FILE TO S3
+        try:
+            connection = Connection(S3_CONFIG).connection
+            bucket = connection.get_bucket(S3_CONFIG.bucket, validate=False)
+            storage = bucket.new_key(filename)
+            storage.set_contents_from_filename(temp_file.abspath, headers={"Content-Type": mimetype.ZIP})
+        except Exception as e:
+            Log.error(
+                "Problem connecting to {{bucket}}", bucket=S3_CONFIG.bucket, cause=e
+            )
+

--- a/vendor/jx_elasticsearch/es52/decoders.py
+++ b/vendor/jx_elasticsearch/es52/decoders.py
@@ -13,7 +13,7 @@ from jx_base.dimensions import Dimension
 from jx_base.domains import DefaultDomain, PARTITION, SimpleSetDomain
 from jx_base.expressions import ExistsOp, FirstOp, GtOp, GteOp, LeavesOp, LtOp, LteOp, MissingOp, TupleOp, Variable
 from jx_base.language import is_op
-from jx_base.query import DEFAULT_LIMIT, MAX_LIMIT
+from jx_base.query import DEFAULT_LIMIT, MAX_LIMIT, temper_limit
 from jx_elasticsearch.es52.es_query import Aggs, FilterAggs, FiltersAggs, NestedAggs, RangeAggs, TermsAggs
 from jx_elasticsearch.es52.expressions import AndOp, InOp, Literal, NotOp
 from jx_elasticsearch.es52.painless import LIST_TO_PIPE, Painless
@@ -512,7 +512,7 @@ class ObjectDecoder(AggsDecoder):
         ])
 
         self.domain = self.edge.domain = wrap({"dimension": {"fields": self.fields}})
-        self.domain.limit = mo_math.min(coalesce(self.domain.limit, query.limit, 10), MAX_LIMIT)
+        self.domain.limit = temper_limit(self.domain.limit, query)
         self.parts = list()
         self.key2index = {}
         self.computed_domain = False
@@ -584,7 +584,7 @@ class DefaultDecoder(SetDecoder):
     def __init__(self, edge, query, limit):
         AggsDecoder.__init__(self, edge, query, limit)
         self.domain = edge.domain
-        self.domain.limit = mo_math.min(coalesce(self.domain.limit, query.limit, 10), MAX_LIMIT)
+        self.domain.limit = temper_limit(self.domain.limit, query)
         self.parts = list()
         self.key2index = {}
         self.computed_domain = False
@@ -681,7 +681,7 @@ class DimFieldListDecoder(SetDecoder):
         edge.allowNulls = False
         self.fields = edge.domain.dimension.fields
         self.domain = self.edge.domain
-        self.domain.limit = mo_math.min(coalesce(self.domain.limit, query.limit, 10), MAX_LIMIT)
+        self.domain.limit = temper_limit(self.domain.limit, query)
         self.parts = list()
 
     def append_query(self, query_path, es_query):

--- a/vendor/jx_elasticsearch/es52/decoders.py
+++ b/vendor/jx_elasticsearch/es52/decoders.py
@@ -626,7 +626,8 @@ class DefaultDecoder(SetDecoder):
             )
             output.add(terms.add(es_query))
 
-        output.add(FilterAggs("_missing", self.missing, self).add(es_query))
+        if self.edge.allowNulls:
+            output.add(FilterAggs("_missing", self.missing, self).add(es_query))
         return output
 
     def count(self, row):
@@ -634,7 +635,10 @@ class DefaultDecoder(SetDecoder):
         if part['doc_count']:
             key = part.get('key')
             if key != None:
-                self.parts.append(self.pull(key))
+                try:
+                    self.parts.append(self.pull(key))
+                except Exception as e:
+                    pass
             else:
                 self.edge.allowNulls = True  # OK! WE WILL ALLOW NULLS
 

--- a/vendor/jx_elasticsearch/es52/decoders.py
+++ b/vendor/jx_elasticsearch/es52/decoders.py
@@ -603,6 +603,7 @@ class DefaultDecoder(SetDecoder):
     def append_query(self, query_path, es_query):
         if is_op(self.edge.value, FirstOp) and is_op(self.edge.value.term, Variable):
             self.edge.value = self.edge.value.term  # ES USES THE FIRST TERM FOR {"terms": } AGGREGATION
+        output = Aggs()
         if not is_op(self.edge.value, Variable):
             terms = TermsAggs(
                 "_match",
@@ -613,6 +614,7 @@ class DefaultDecoder(SetDecoder):
                 },
                 self
             )
+            output.add(FilterAggs("_filter", self.exists, None).add(terms.add(es_query)))
         else:
             terms = TermsAggs(
                 "_match", {
@@ -622,8 +624,8 @@ class DefaultDecoder(SetDecoder):
                 },
                 self
             )
-        output = Aggs()
-        output.add(FilterAggs("_filter", self.exists, None).add(terms.add(es_query)))
+            output.add(terms.add(es_query))
+
         output.add(FilterAggs("_missing", self.missing, self).add(es_query))
         return output
 

--- a/vendor/jx_python/containers/list_usingPythonList.py
+++ b/vendor/jx_python/containers/list_usingPythonList.py
@@ -204,10 +204,6 @@ class ListContainer(Container, jx_base.Namespace, jx_base.Table):
         jx.window(self.data, window)
         return self
 
-    def having(self, having):
-        _ = having
-        raise NotImplementedError()
-
     def format(self, format):
         if format == "table":
             frum = convert.list2table(self.data, self._schema.lookup.keys())

--- a/vendor/jx_python/namespace/normal.py
+++ b/vendor/jx_python/namespace/normal.py
@@ -77,8 +77,6 @@ class Normal(Namespace):
         if not mo_math.is_integer(output.limit) or output.limit < 0:
             Log.error("Expecting limit >= 0")
 
-        output.isLean = query.isLean
-
         # DEPTH ANALYSIS - LOOK FOR COLUMN REFERENCES THAT MAY BE DEEPER THAN
         # THE from SOURCE IS.
         vars = get_all_vars(output, exclude_where=True)  # WE WILL EXCLUDE where VARIABLES

--- a/vendor/jx_python/namespace/normal.py
+++ b/vendor/jx_python/namespace/normal.py
@@ -9,6 +9,8 @@
 #
 from __future__ import absolute_import, division, unicode_literals
 
+from jx_base.expressions import Variable
+from jx_base.language import is_op
 from mo_future import is_text, is_binary
 from copy import copy
 
@@ -83,8 +85,6 @@ class Normal(Namespace):
         for c in query.columns:
             if c.name in vars and len(c.nested_path) != 1:
                 Log.error("This query, with variable {{var_name}} is too deep", var_name=c.name)
-
-        output.having = convert_list(self._convert_having, query.having)
 
         return output
 

--- a/vendor/jx_python/namespace/rename.py
+++ b/vendor/jx_python/namespace/rename.py
@@ -75,7 +75,6 @@ class Rename(Namespace):
         output.where = self.convert(query.where)
         output.frum = self._convert_from(query.frum)
         output.edges = convert_list(self._convert_edge, query.edges)
-        output.having = convert_list(self._convert_having, query.having)
         output.window = convert_list(self._convert_window, query.window)
         output.sort = self._convert_clause(query.sort)
         output.format = query.format

--- a/vendor/mo_files/__init__.py
+++ b/vendor/mo_files/__init__.py
@@ -8,11 +8,12 @@
 # Author: Kyle Lahnakoski (kyle@lahnakoski.com)
 #
 import base64
-from datetime import datetime
 import io
 import os
 import re
 import shutil
+from datetime import datetime
+from mimetypes import MimeTypes
 from tempfile import NamedTemporaryFile, mkdtemp
 
 from mo_dots import Null, coalesce, get_module, is_list
@@ -146,7 +147,6 @@ class File(object):
             elif self.abspath.endswith(".json"):
                 self._mime_type = mimetype.JSON
             else:
-                from mimetype import MimeTypes
                 mime = MimeTypes()
                 self._mime_type, _ = mime.guess_type(self.abspath)
                 if not self._mime_type:
@@ -187,7 +187,7 @@ class File(object):
         """
         RETURN NEW FILE WITH EXTENSION ADDED (OLD EXTENSION IS A SUFFIX)
         """
-        return File(self._filename + "." + text_type(ext))
+        return File(self._filename + "." + text(ext))
 
     def set_name(self, name):
         """

--- a/vendor/mo_files/mimetype.py
+++ b/vendor/mo_files/mimetype.py
@@ -1,3 +1,4 @@
 from mo_future import text
 
 JSON = text("application/json")
+ZIP = text("application/zip")

--- a/vendor/mo_math/randoms.py
+++ b/vendor/mo_math/randoms.py
@@ -27,8 +27,8 @@ class Random(object):
         return Random.string(length, string.digits + "ABCDEF")
 
     @staticmethod
-    def base64(length):
-        return Random.string(length, SIMPLE_ALPHABET + "+/")
+    def base64(length, extra="+/"):
+        return Random.string(length, SIMPLE_ALPHABET + extra)
 
     @staticmethod
     def int(*args):


### PR DESCRIPTION
https://github.com/mozilla/ActiveData/issues/126

You may now bulk query, but your query will have severe restrictions it must match this pattern:

```
{
    "groupby":"a.column.name",
    "format":"list",
    "destination":"s3"   
}
```

* `edges` are not allowed
* `groupby` must be a string; a column name
* `limit` is ignored
* `format` must be `list`
* `destination` must be `s3`
* **no restrictions on the other clauses** 

If anything is off, the query gets shunted to regular query processing:
https://github.com/mozilla/ActiveData/blob/22da05ac5b4183e3900e18ac2229cb584ba912ac/vendor/jx_elasticsearch/es52/bulk_aggs.py#L38

Here is a template for the response:
 
```
{
    "url":some_url_to_get_result,
    "meta": {"cardinality": the_number_of_rows_expected}
}
```

Check the `url` periodically to get the response 