### PR TITLE
Fixes for previous changes

### DIFF
--- a/active_data/actions/__init__.py
+++ b/active_data/actions/__init__.py
@@ -52,7 +52,7 @@ def send_error(active_data_timer, body, e):
     return Response(value2json(e).encode("utf8"), status=status)
 
 
-def test_mode_wait(query):
+def test_mode_wait(query, please_stop):
     """
     WAIT FOR METADATA TO ARRIVE ON INDEX
     :param query: dict() OF REQUEST BODY
@@ -76,7 +76,7 @@ def test_mode_wait(query):
         ):
             metadata_manager = find_container(alias, after=after).namespace
 
-            timeout = Till(seconds=MINUTE.seconds)
+            timeout = Till(seconds=MINUTE.seconds) | please_stop
             while not timeout:
                 # GET FRESH VERSIONS
                 cols = metadata_manager.get_columns(

--- a/active_data/actions/query.py
+++ b/active_data/actions/query.py
@@ -20,7 +20,7 @@ from mo_files import File
 from mo_future import binary_type
 from mo_json import json2value, value2json
 from mo_logs import Except, Log
-from mo_threads.threads import register_thread
+from mo_threads.threads import register_thread, MAIN_THREAD
 from mo_times.timer import Timer
 from pyLibrary.env.flask_wrappers import cors_wrapper
 
@@ -53,7 +53,7 @@ def jx_query(path):
                 data = json2value(text)
                 record_request(flask.request, data, None, None)
                 if data.meta.testing:
-                    test_mode_wait(data)
+                    test_mode_wait(data, MAIN_THREAD.please_stop)
 
             find_table_timer = Timer("find container", verbose=DEBUG)
             with find_table_timer:

--- a/active_data/actions/sql.py
+++ b/active_data/actions/sql.py
@@ -23,7 +23,7 @@ from mo_json import json2value, value2json
 from mo_logs import Log
 from mo_logs.exceptions import Except
 from mo_testing.fuzzytestcase import assertAlmostEqual
-from mo_threads.threads import register_thread
+from mo_threads.threads import register_thread, MAIN_THREAD
 from mo_times.timer import Timer
 from pyLibrary.env.flask_wrappers import cors_wrapper
 
@@ -61,7 +61,7 @@ def sql_query(path):
                 jx_query = parse_sql(data.sql)
                 if jx_query['from'] != None:
                     if data.meta.testing:
-                        test_mode_wait(jx_query)
+                        test_mode_wait(jx_query, MAIN_THREAD.please_stop)
                     frum = find_container(jx_query['from'], after=None)
                 else:
                     frum = None

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ requests==2.18.4
 moz-sql-parser
 boto==2.48.0
 beautifulsoup4==4.6.0
-cryptography==2.1.4
+

--- a/tests/test_jx/test_schema_merging.py
+++ b/tests/test_jx/test_schema_merging.py
@@ -370,7 +370,7 @@ class TestSchemaMerging(BaseTestCase):
         }
         self.utils.execute_tests(test)
 
-    # @skip("For Orange query")
+    @skip("For Orange query")
     def test_edge(self):
         test = {
             "data": [

--- a/tests/test_jx/test_schema_merging.py
+++ b/tests/test_jx/test_schema_merging.py
@@ -329,7 +329,7 @@ class TestSchemaMerging(BaseTestCase):
             "expecting_cube": {
                 "meta": {"format": "cube"},
                 "data": {
-                    "a.b": [2, 4]
+                    "k": [2, 4]
                 }
             }
         }

--- a/tests/test_jx/test_schema_merging.py
+++ b/tests/test_jx/test_schema_merging.py
@@ -301,6 +301,7 @@ class TestSchemaMerging(BaseTestCase):
         }
         self.utils.execute_tests(test)
 
+    @skip("complicated where clause needs support")
     def test_where(self):
         test = {
             "data": [
@@ -369,7 +370,7 @@ class TestSchemaMerging(BaseTestCase):
         }
         self.utils.execute_tests(test)
 
-    @skip("For Orange query")
+    # @skip("For Orange query")
     def test_edge(self):
         test = {
             "data": [
@@ -394,18 +395,7 @@ class TestSchemaMerging(BaseTestCase):
                     {"b": 4, "v": 5},
                     {"v": 14}
                 ]
-            },
-            # "expecting_table": {
-            #     "meta": {"format": "table"},
-            #     "header": ["a.b"],
-            #     "data": [[8]]
-            # },
-            # "expecting_cube": {
-            #     "meta": {"format": "cube"},
-            #     "data": {
-            #         "a.b": 8
-            #     }
-            # }
+            }
         }
         self.utils.execute_tests(test)
 

--- a/tests/test_jx/test_schema_merging.py
+++ b/tests/test_jx/test_schema_merging.py
@@ -301,6 +301,40 @@ class TestSchemaMerging(BaseTestCase):
         }
         self.utils.execute_tests(test)
 
+    def test_where(self):
+        test = {
+            "data": [
+                {"k": 1, "a": "b"},
+                {"k": 2, "a": {"b": 1}},
+                {"k": 3, "a": {}},
+                {"k": 4, "a": [{"b": 1}, {"b": 2}]},  # TEST THAT INNER CAN BE MAPPED TO NESTED
+                {"k": 5, "a": {"b": 4}},  # TEST THAT INNER IS MAPPED TO NESTED, AFTER SEEING NESTED
+                {"k": 6, "a": 3},
+                {"k": 7, }
+            ],
+            "query": {
+                "from": TEST_TABLE + ".a",
+                "select": ["k"],
+                "where": {"eq": {"a.b": 1}}
+            },
+            "expecting_list": {
+                "meta": {"format": "list"},
+                "data": [{"k": 2}, {"k": 4}]
+            },
+            "expecting_table": {
+                "meta": {"format": "table"},
+                "header": ["k"],
+                "data": [[2], [4]]
+            },
+            "expecting_cube": {
+                "meta": {"format": "cube"},
+                "data": {
+                    "a.b": [2, 4]
+                }
+            }
+        }
+        self.utils.execute_tests(test)
+
     # @skip("schema merging not working")
     def test_sum(self):
         test = {

--- a/vendor/jx_base/__init__.py
+++ b/vendor/jx_base/__init__.py
@@ -11,13 +11,15 @@ from __future__ import absolute_import, division, unicode_literals
 
 from uuid import uuid4
 
+from mo_json.typed_encoder import EXISTS_TYPE
+
 from jx_base.expressions import jx_expression
 from jx_python.expressions import Literal, Python
 from mo_dots import coalesce, listwrap, wrap
 from mo_dots.datas import register_data
 from mo_dots.lists import last
 from mo_future import is_text, text
-from mo_json import value2json, true, false, null
+from mo_json import value2json, true, false, null, EXISTS
 from mo_logs import Log
 from mo_logs.strings import expand_template, quote
 
@@ -115,8 +117,7 @@ class {{class_name}}(Mapping):
             "constraint\\n{" + "{code}}\\nnot satisfied {" + "{expect}}\\n{" + "{value|indent}}",
             code={{constraint_expr|quote}}, 
             expect={{constraint}}, 
-            value=row,
-            cause=e
+            value=row
         )
 
     def __init__(self, **kwargs):
@@ -238,6 +239,11 @@ Column = DataClass(
             {"not": {"find": {"es_column": "null"}}},
             {"not": {"eq": {"es_column": "string"}}},
             {"not": {"eq": {"es_type": "object", "jx_type": "exists"}}},
+            {
+                "when": {"suffix": {"es_column": "." + EXISTS_TYPE}},
+                "then": {"eq": {"jx_type": EXISTS}},
+                "else": True
+            },
             {"eq": [{"last": "nested_path"}, {"literal": "."}]},
             {
                 "when": {"eq": [{"literal": ".~N~"}, {"right": {"es_column": 4}}]},

--- a/vendor/jx_elasticsearch/meta_columns.py
+++ b/vendor/jx_elasticsearch/meta_columns.py
@@ -497,7 +497,7 @@ def doc_to_column(doc):
 
 def mark_as_deleted(col):
     col.count = 0
-    col.cardinality = -1
+    col.cardinality = 0
     col.multi = 1001 if col.es_type == "nested" else 0,
     col.partitions = None
     col.last_updated = Date.now()

--- a/vendor/jx_elasticsearch/meta_columns.py
+++ b/vendor/jx_elasticsearch/meta_columns.py
@@ -21,7 +21,7 @@ from mo_json.typed_encoder import unnest_path, untype_path, untyped, NESTED_TYPE
 from mo_logs import Log
 from mo_math import MAX
 from mo_threads import Lock, MAIN_THREAD, Queue, Thread, Till
-from mo_times import YEAR
+from mo_times import YEAR, Timer
 from mo_times.dates import Date
 
 DEBUG = False


### PR DESCRIPTION
The inclusion of many more columns allowed `*.~e~` to leak into queries, causing query breakage.  No tests to detect this have been added